### PR TITLE
Add another pattern to ZipDistro.ZipIgnore

### DIFF
--- a/Editor/Distros/ZipDistro.cs
+++ b/Editor/Distros/ZipDistro.cs
@@ -108,6 +108,7 @@ public class ZipDistro : DistroBase
         "Thumbs.db",
         "desktop.ini",
         "*_BackUpThisFolder_ButDontShipItWithYourGame",
+        "*_BurstDebugInformation_DoNotShip",
         BuildInfo.DEFAULT_NAME
     };
     static Regex[] ZipIgnorePatterns;


### PR DESCRIPTION
`*_BurstDebugInformation_DoNotShip` is generated in debug builds for projects that use Burst.