### PR TITLE
Fix #13

### DIFF
--- a/Base/Option.cs
+++ b/Base/Option.cs
@@ -16,6 +16,7 @@ using sttz.Trimmer.Extensions;
 using System.Diagnostics;
 
 #if UNITY_EDITOR
+using JetBrains.Annotations;
 using UnityEditor;
 using UnityEditor.Build.Reporting;
 #endif
@@ -589,8 +590,12 @@ public abstract class Option
     /// > [!NOTE]
     /// > This method is only available in the editor.
     /// </remarks>
-    /// <param name="report">Unity's build report</param>
-    public virtual void OnBuildError(BuildReport report)
+    /// <param name="report">
+    /// The build report that Unity provided,
+    /// or <see langword="null"/> if the build failed before
+    /// the player itself could be compiled.
+    /// </param>
+    public virtual void OnBuildError([CanBeNull] BuildReport report)
     {
         if (variants != null) {
             foreach (var variant in variants) {

--- a/Editor/BuildManager.cs
+++ b/Editor/BuildManager.cs
@@ -458,8 +458,7 @@ public class BuildManager : IProcessSceneWithReport, IPreprocessBuildWithReport,
         currentProfile = buildProfile;
         currentTarget = options.target;
 
-        try
-        {
+        try {
             // Add Trimmer scripting define symbols
             AddScriptingDefineSymbols(buildProfile, ref options);
 
@@ -470,8 +469,7 @@ public class BuildManager : IProcessSceneWithReport, IPreprocessBuildWithReport,
                 options = option.PrepareBuild(options, inclusion);
             }
         }
-        catch (Exception)
-        {
+        catch (Exception) {
             OnBuildError(null);
             throw;
         }


### PR DESCRIPTION
Here, what do you think about this?

- Call OnBuildError if PrepareBuild or GetScriptingDefineSymbols throws an exception
- Also call it if the user didn't (or couldn't) pick a build location if it wasn't already given
- Mark the argument to OnBuildError as [CanBeNull]