### PR TITLE
Use scopes to manage editor layouts

### DIFF
--- a/Editor/ProfileEditor.cs
+++ b/Editor/ProfileEditor.cs
@@ -635,7 +635,8 @@ public class ProfileEditor : UnityEditor.Editor
         var width = GUILayout.Width(EditorGUIUtility.labelWidth - 4);
 
         var isRoot = (option.Parent == null && !showDefaultVariant);
-        using var indentScope = new EditorGUI.IndentLevelScope(EditorGUI.indentLevel - depth);
+        var lastDepth = EditorGUI.indentLevel;
+        EditorGUI.indentLevel = depth;
 
         if (buildProfile != null && isRoot) {
             optionAvailable = option.IsAvailable(buildProfile.BuildTargets);
@@ -721,10 +722,10 @@ public class ProfileEditor : UnityEditor.Editor
                     EditorGUILayout.PrefixLabel(" ");
                 }
 
-                using (new EditorGUI.IndentLevelScope(-EditorGUI.indentLevel))
-                { // Briefly set indent level to 0
-                    profile.EditOption(option);
-                }
+                var level = EditorGUI.indentLevel;
+                EditorGUI.indentLevel = 0;
+                profile.EditOption(option);
+                EditorGUI.indentLevel = level;
 
                 if (!isDefault) {
                     if (GUILayout.Button(GUIContent.none, minusStyle)) {
@@ -740,10 +741,10 @@ public class ProfileEditor : UnityEditor.Editor
                 tempContent.text = displayName;
                 EditorGUILayout.PrefixLabel(tempContent);
 
-                using (new EditorGUI.IndentLevelScope(-EditorGUI.indentLevel))
-                { // Briefly set indent level to 0
-                    profile.EditOption(option);
-                }
+                var level = EditorGUI.indentLevel;
+                EditorGUI.indentLevel = 0;
+                profile.EditOption(option);
+                EditorGUI.indentLevel = level;
             }
 
             // Include in build toggle
@@ -787,6 +788,8 @@ public class ProfileEditor : UnityEditor.Editor
                 EditorProfile.Instance.SetExpanded(expansionPath, isExpanded);
             }
         }
+
+        EditorGUI.indentLevel = lastDepth;
 
         return isExpanded;
     }

--- a/Editor/ProfileEditor.cs
+++ b/Editor/ProfileEditor.cs
@@ -142,7 +142,7 @@ public class ProfileEditor : UnityEditor.Editor
     /// </summary>
     public static bool Foldout(string path, bool def, string content, GUIStyle style = null)
     {
-        EditorGUI.BeginChangeCheck();
+        using var _ = new EditorGUI.ChangeCheckScope();
         
         var wasExpanded = EditorProfile.Instance.IsExpanded(path);
         if (def) wasExpanded = !wasExpanded;

--- a/Editor/ProfileEditor.cs
+++ b/Editor/ProfileEditor.cs
@@ -474,7 +474,7 @@ public class ProfileEditor : UnityEditor.Editor
     void SourceProfileGUI()
     {
         if (editorProfile != null) {
-            EditorGUILayout.BeginHorizontal();
+            using (new EditorGUILayout.HorizontalScope())
             {
                 if (sourceProfiles == null) {
                     sourceProfiles = BuildProfile.AllBuildProfiles.Prepend(null).ToArray();
@@ -501,7 +501,6 @@ public class ProfileEditor : UnityEditor.Editor
                 }
                 GUI.enabled = true;
             }
-            EditorGUILayout.EndHorizontal();
         }
     }
 
@@ -525,7 +524,7 @@ public class ProfileEditor : UnityEditor.Editor
         EditorGUILayout.Space();
 
         var usesActive = buildProfile.UsesActiveBuildTarget();
-        EditorGUILayout.BeginHorizontal();
+        using (new EditorGUILayout.HorizontalScope())
         {
             GUILayout.Label("Build Targets", boldLabel);
             if (GUILayout.Button(GUIContent.none, plusStyle)) {
@@ -544,11 +543,10 @@ public class ProfileEditor : UnityEditor.Editor
             }
             GUILayout.FlexibleSpace();
         }
-        EditorGUILayout.EndHorizontal();
 
         foreach (var target in buildProfile.BuildTargets) {
-            EditorGUILayout.BeginHorizontal();
-            EditorGUI.BeginDisabledGroup(usesActive);
+            using var _ = new EditorGUILayout.HorizontalScope();
+            using (new EditorGUI.DisabledGroupScope(usesActive))
             {
                 if (GUILayout.Button(GUIContent.none, minusStyle)) {
                     delayedRemovals.Add(() => {
@@ -557,7 +555,6 @@ public class ProfileEditor : UnityEditor.Editor
                 }
                 EditorGUILayout.LabelField(target.ToString());
             }
-            EditorGUI.EndDisabledGroup();
 
             var path = buildProfile.GetLastBuildPath(target);
             if (!string.IsNullOrEmpty(path) 
@@ -565,27 +562,23 @@ public class ProfileEditor : UnityEditor.Editor
                     && GUILayout.Button("Show", EditorStyles.miniButton, GUILayout.ExpandWidth(false))) {
                 EditorUtility.RevealInFinder(path);
             }
-            EditorGUI.BeginDisabledGroup(BuildRunner.Current != null);
+            using (new EditorGUI.DisabledGroupScope(BuildRunner.Current != null))
             {
                 if (GUILayout.Button("Build", EditorStyles.miniButton, GUILayout.ExpandWidth(false))) {
                     BuildManager.Build(buildProfile, target);
                 }
             }
-            EditorGUI.EndDisabledGroup();
-
-            EditorGUILayout.EndHorizontal();
         }
 
         EditorGUILayout.Space();
 
-        EditorGUI.BeginDisabledGroup(BuildRunner.Current != null);
+        using (new EditorGUI.DisabledGroupScope(BuildRunner.Current != null))
         {
             var count = buildProfile.BuildTargets.Count();
             if (GUILayout.Button("Build " + count + " Target" + (count > 1 ? "s" : ""), EditorStyles.miniButton)) {
                 BuildManager.Build(buildProfile);
             }
         }
-        EditorGUI.EndDisabledGroup();
     }
 
     protected void AddBuildTarget(object userData)
@@ -673,12 +666,11 @@ public class ProfileEditor : UnityEditor.Editor
             }
 
             if (category != lastCategory) {
-                EditorGUILayout.BeginHorizontal(categoryBackground);
+                using (new EditorGUILayout.HorizontalScope(categoryBackground))
                 {
                     var path = pathBase + "_" + category;
                     categoryExpanded = Foldout(path, true, category, categoryFoldout);
                 }
-                EditorGUILayout.EndHorizontal();
                 lastCategory = category;
             } else if (categoryExpanded) {
                 GUILayout.Label(GUIContent.none, separator);
@@ -707,9 +699,9 @@ public class ProfileEditor : UnityEditor.Editor
 
                 if (option.Variance == OptionVariance.Dictionary) {
                     // Disable when editing the default variant
-                    EditorGUI.BeginDisabledGroup(isDefault);
+                    using (new EditorGUI.DisabledGroupScope(isDefault))
                     {
-                        EditorGUI.BeginDisabledGroup(isDefault);
+                        using (new EditorGUI.DisabledGroupScope(isDefault))
                         {
                             var newParam = EditorGUILayout.DelayedTextField(option.VariantParameter, width);
                             if (newParam != option.VariantParameter) {
@@ -721,9 +713,7 @@ public class ProfileEditor : UnityEditor.Editor
                                 Option.changed = true;
                             }
                         }
-                        EditorGUI.EndDisabledGroup();
                     }
-                    EditorGUI.EndDisabledGroup();
                 } else {
                     EditorGUILayout.PrefixLabel(" ");
                 }
@@ -759,7 +749,7 @@ public class ProfileEditor : UnityEditor.Editor
                 color.a = 1;
                 GUI.color = color;
                 
-                EditorGUILayout.BeginHorizontal(includeBackground, GUILayout.Width(buildColumnWidth), GUILayout.Height(lineHeight));
+                using (new EditorGUILayout.HorizontalScope(includeBackground, GUILayout.Width(buildColumnWidth), GUILayout.Height(lineHeight)))
                 {
                     if (
                         buildProfile != null
@@ -769,18 +759,16 @@ public class ProfileEditor : UnityEditor.Editor
                             || (option.Capabilities & OptionCapabilities.HasAssociatedFeature) != 0
                         )
                     ) {
-                        EditorGUI.BeginDisabledGroup(!optionAvailable);
+                        using var _ = new EditorGUI.DisabledGroupScope(!optionAvailable);
                         var root = buildProfile.Store.GetOrCreateRoot(option.Name);
                         GUILayout.Label(LabelForInclusion(root, option.Capabilities), inclusionLabel);
                         if (optionAvailable) {
                             DoInclusionMenu(root, option.Capabilities);
                         }
-                        EditorGUI.EndDisabledGroup();
                     } else {
                         EditorGUILayout.Space();
                     }
                 }
-                EditorGUILayout.EndHorizontal();
             } else {
                 // Not including a layout group here somehow makes the parent group taller
                 EditorGUILayout.BeginHorizontal(GUILayout.Width(0));

--- a/Editor/ProfileEditor.cs
+++ b/Editor/ProfileEditor.cs
@@ -635,8 +635,7 @@ public class ProfileEditor : UnityEditor.Editor
         var width = GUILayout.Width(EditorGUIUtility.labelWidth - 4);
 
         var isRoot = (option.Parent == null && !showDefaultVariant);
-        var lastDepth = EditorGUI.indentLevel;
-        EditorGUI.indentLevel = depth;
+        using var indentScope = new EditorGUI.IndentLevelScope(EditorGUI.indentLevel - depth);
 
         if (buildProfile != null && isRoot) {
             optionAvailable = option.IsAvailable(buildProfile.BuildTargets);
@@ -722,10 +721,10 @@ public class ProfileEditor : UnityEditor.Editor
                     EditorGUILayout.PrefixLabel(" ");
                 }
 
-                var level = EditorGUI.indentLevel;
-                EditorGUI.indentLevel = 0;
-                profile.EditOption(option);
-                EditorGUI.indentLevel = level;
+                using (new EditorGUI.IndentLevelScope(-EditorGUI.indentLevel))
+                { // Briefly set indent level to 0
+                    profile.EditOption(option);
+                }
 
                 if (!isDefault) {
                     if (GUILayout.Button(GUIContent.none, minusStyle)) {
@@ -741,10 +740,10 @@ public class ProfileEditor : UnityEditor.Editor
                 tempContent.text = displayName;
                 EditorGUILayout.PrefixLabel(tempContent);
 
-                var level = EditorGUI.indentLevel;
-                EditorGUI.indentLevel = 0;
-                profile.EditOption(option);
-                EditorGUI.indentLevel = level;
+                using (new EditorGUI.IndentLevelScope(-EditorGUI.indentLevel))
+                { // Briefly set indent level to 0
+                    profile.EditOption(option);
+                }
             }
 
             // Include in build toggle
@@ -788,8 +787,6 @@ public class ProfileEditor : UnityEditor.Editor
                 EditorProfile.Instance.SetExpanded(expansionPath, isExpanded);
             }
         }
-
-        EditorGUI.indentLevel = lastDepth;
 
         return isExpanded;
     }

--- a/Editor/ProfileEditor.cs
+++ b/Editor/ProfileEditor.cs
@@ -113,19 +113,21 @@ public class ProfileEditor : UnityEditor.Editor
         if (style == null) style = EditorStyles.foldout;
 
         // Wrap foldout into a layout region to get the foldout's rect
-        var rect = EditorGUILayout.BeginHorizontal(GUIStyle.none);
-        var clicked = false;
+        bool newFoldout = false;
+        bool clicked = false;
+        using (var rectScope = new EditorGUILayout.HorizontalScope(GUIStyle.none))
+        {
+            var rect = rectScope.rect;
 
-        // Determine if it is being clicked on the foldout before
-        // calling it to avoid it eating the event
-        if (Event.current.type == EventType.MouseUp
-            && rect.Contains(Event.current.mousePosition)) {
-            clicked = true;
+            // Determine if it is being clicked on the foldout before
+            // calling it to avoid it eating the event
+            if (Event.current.type == EventType.MouseUp
+                && rect.Contains(Event.current.mousePosition)) {
+                clicked = true;
+            }
+
+            newFoldout = EditorGUILayout.Foldout(foldout, content, style);
         }
-
-        var newFoldout = EditorGUILayout.Foldout(foldout, content, style);
-
-        EditorGUILayout.EndHorizontal();
 
         // Act in case we saw a click but the foldout didn't toggle
         if (newFoldout == foldout && clicked) {
@@ -683,8 +685,10 @@ public class ProfileEditor : UnityEditor.Editor
 
         // Option GUI
         var lineHeight = EditorGUIUtility.singleLineHeight + linePadding;
-        var rect = EditorGUILayout.BeginHorizontal(GUILayout.Height(lineHeight));
+        Rect rect;
+        using (var rectScope = new EditorGUILayout.HorizontalScope(GUILayout.Height(lineHeight)))
         {
+            rect = rectScope.rect;
             // Variant container
             if (option.IsDefaultVariant && !showDefaultVariant) {
                 EditorGUILayout.LabelField(displayName, width);
@@ -771,11 +775,9 @@ public class ProfileEditor : UnityEditor.Editor
                 }
             } else {
                 // Not including a layout group here somehow makes the parent group taller
-                EditorGUILayout.BeginHorizontal(GUILayout.Width(0));
-                EditorGUILayout.EndHorizontal();
+                using var _ = new EditorGUILayout.HorizontalScope(GUILayout.Width(0));
             }
         }
-        EditorGUILayout.EndHorizontal();
 
         // Expansion toggle
         if (expandable) {


### PR DESCRIPTION
This PR replaces [`EditorGUI.BeginDisabledGroup`](https://docs.unity3d.com/2022.1/Documentation/ScriptReference/EditorGUI.BeginDisabledGroup.html) with [`EditorGUI.DisabledGroupScope`](https://docs.unity3d.com/2022.1/Documentation/ScriptReference/EditorGUI.DisabledGroupScope.html). Ditto for a couple of similar editor layouts.

Using the scopes means that you won't have to manually match `Begin`s and `End`s, as the scopes implement `IDisposable`. This way, an errant exception or control-flow statement won't risk breaking the UI.