### PR TITLE
ProcessStartInfo.ArgumentList vs. Arguments in Windows

### DIFF
--- a/Editor/Distros/ItchDistro.cs
+++ b/Editor/Distros/ItchDistro.cs
@@ -106,12 +106,23 @@ public class ItchDistro : DistroBase
             }
         }
 
-        var args = string.Format(
-            "push '{0}' '{1}:{2}' --userversion '{3}' --ignore='*.DS_Store' --ignore='build.json'",
-            path, project, channel, Application.version
-        );
+        var startInfo = new System.Diagnostics.ProcessStartInfo();
+        var argv = startInfo.ArgumentList;
+        
+        argv.Add("push");
+        argv.Add(path);
+        argv.Add($"{project}:{channel}");
+        argv.Add($"--userversion"); argv.Add(Application.version);
+        argv.Add("--ignore"); argv.Add("*.DS_Store");
+        argv.Add("--ignore"); argv.Add("build.json");
+        
+        startInfo.FileName = butlerPath;
+        startInfo.UseShellExecute = false;
 
-        await Execute(new ExecutionArgs(butlerPath, args), task);
+        var argvStr = String.Join("> <", argv);
+        task.Report(0, description: $"Executing {butlerPath}: <{argvStr}>");
+
+        await Execute(new ExecutionArgs() { startInfo = startInfo }, task);
     }
 }
 

--- a/Editor/Distros/ZipDistro.cs
+++ b/Editor/Distros/ZipDistro.cs
@@ -280,21 +280,23 @@ public class ZipDistro : DistroBase
         }
 
         // Run 7za command to create ZIP file
-        var excludes = "";
+        
+        var startInfo = new System.Diagnostics.ProcessStartInfo();
+        var argv = startInfo.ArgumentList;
+        var inputName = Path.GetFileName(basePath);
+        
+        argv.Add("a");
+        argv.Add(outputPath);
+        argv.Add(inputName);
+        argv.Add(((int)compression).ToString());
+        
         foreach (var pattern in ZipIgnore) {
-            excludes += @" -xr\!'" + pattern + "'";
+            argv.Add(@" -xr!" + pattern);
         }
 
-        var inputName = Path.GetFileName(basePath);
-        var args = string.Format(
-            "a '{0}' '{1}' -mx{2} {3}",
-            outputPath, inputName, (int)compression, excludes
-        );
-
-        var startInfo = new System.Diagnostics.ProcessStartInfo();
         startInfo.FileName = sevenZPath;
-        startInfo.Arguments = args;
         startInfo.WorkingDirectory = Path.GetDirectoryName(basePath);
+        startInfo.UseShellExecute = false;
 
         task.Report(0, description: $"Archiving {inputName}");
 
@@ -313,11 +315,14 @@ public class ZipDistro : DistroBase
             throw new Exception("ZipDistro: Path to archive does not exist: " + archivePath);
         }
 
-        var args = string.Format(
-            "rn '{0}' '{1}' '{2}'",
-            archivePath, oldName, newName
-        );
-        await Execute(new ExecutionArgs(Get7ZipPath(), args), task);
+        var startInfo = new System.Diagnostics.ProcessStartInfo(Get7ZipPath());
+        var argv = startInfo.ArgumentList;
+        argv.Add("rn");
+        argv.Add(archivePath);
+        argv.Add(oldName);
+        argv.Add(newName);
+
+        await Execute(new ExecutionArgs(startInfo), task);
     }
 
     protected override async Task RunDistribute(IEnumerable<BuildPath> buildPaths, TaskToken task)

--- a/Editor/Distros/ZipDistro.cs
+++ b/Editor/Distros/ZipDistro.cs
@@ -4,10 +4,8 @@
 //
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -299,7 +297,7 @@ public class ZipDistro : DistroBase
         startInfo.WorkingDirectory = Path.GetDirectoryName(basePath);
         startInfo.UseShellExecute = false;
 
-        var argvStr = String.Join("> <", argv.ToArray());
+        var argvStr = String.Join("> <", argv);
         task.Report(0, description: $"Archiving {inputName}: <{argvStr}>");
 
         await Execute(new ExecutionArgs() { startInfo = startInfo }, task);

--- a/Editor/Distros/ZipDistro.cs
+++ b/Editor/Distros/ZipDistro.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -288,17 +289,18 @@ public class ZipDistro : DistroBase
         argv.Add("a");
         argv.Add(outputPath);
         argv.Add(inputName);
-        argv.Add(((int)compression).ToString());
+        argv.Add($"-mx{(int)compression}");
         
         foreach (var pattern in ZipIgnore) {
-            argv.Add(@" -xr!" + pattern);
+            argv.Add(@"-xr!" + pattern);
         }
 
         startInfo.FileName = sevenZPath;
         startInfo.WorkingDirectory = Path.GetDirectoryName(basePath);
         startInfo.UseShellExecute = false;
 
-        task.Report(0, description: $"Archiving {inputName}");
+        var argvStr = String.Join("> <", argv.ToArray());
+        task.Report(0, description: $"Archiving {inputName}: <{argvStr}>");
 
         await Execute(new ExecutionArgs() { startInfo = startInfo }, task);
 


### PR DESCRIPTION
Windows doesn't have a proper shell to speak of, and it's really bad at quoting.  Was having problems with ZipDistro, so I converted the references to command line arguments in System.Diagnostics.ProcessStartInfo to use ArgumentList instead of Arguments.  The elements added to ArgumentList shouldn't need to be quoted or escaped, because they will passed directly to the subprocess.

I haven't looked for other places that ProcessStartInfo is used in this project, but I assume that they would benefit from a similar treatment.